### PR TITLE
Fixed wrong word

### DIFF
--- a/docs/reference/PDDL2.2/domain.md
+++ b/docs/reference/PDDL2.2/domain.md
@@ -104,4 +104,4 @@ Note, that a derived predicate is declared similarly to actions, in that we use 
 )
 ```
 
-The example above specifies that a train is only usable if it has a train and a driver.
+The example above specifies that a train is only usable if it has a guard and a driver.


### PR DESCRIPTION
Fixes #82 
---
Replaced 'train ' with 'guard'
to make the sentence accurate in describing the code shown above 