### PR TITLE
:condition-effects -> :conditional-effects

### DIFF
--- a/docs/reference/PDDL/requirements.md
+++ b/docs/reference/PDDL/requirements.md
@@ -374,7 +374,7 @@ ADL is a super requirement which adds the following requirements
 - `:disjunctive-preconditions`
 - `:equality`
 - `:quantified-preconditions`
-- `:condition-effects`
+- `:conditional-effects`
 
 ## UCPOP
 


### PR DESCRIPTION
Looks like the `:condition-effects` mentioned in the `:adl` is a typo. Should be `:conditional-effects`, right?